### PR TITLE
removed device property

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -20,8 +20,7 @@ module.exports.Browser = Browser
 util.inherits(Browser, EventEmitter)
 
 Browser.prototype.update = function (device) {
-	this.device = new Device(device)
-	this.emit('deviceOn', this.device)
+	this.emit('deviceOn', new Device(device))
 }
 
 Browser.prototype.init = function () {


### PR DESCRIPTION
Not needed since devices are discover asynchronously, so you need to subscribe to event in any case.