### PR TITLE
gc dns object

### DIFF
--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -124,5 +124,6 @@ Browser.prototype.stop = function () {
 	if (dns) {
 		dns.removeAllListeners()
 		dns.destroy()
+		this._dns = null
 	}
 }


### PR DESCRIPTION
Not needed since devices are discover asynchronously, so you need to subscribe to event in any case.