### PR TITLE
Missing parenthesis in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ client.on('device', function (device) {
   device.play(media, function (err) {
     if (!err) console.log('Playing in your chromecast')
   })
-}
+})
 ```
 
 ## API


### PR DESCRIPTION
Simply pasting and running this whole example as-is, fails in error. Adding parenthesis fixes issue.