### PR TITLE
FIXED: reset nullify device.client when status returns error

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -156,7 +156,10 @@ class Device extends EventEmitter {
 
   getStatus (callback) {
     this._tryJoin((err) => {
-      if (err) return callback(err)
+      if (err) {
+        this.client = null
+        return callback(err)
+      }
 
       this.player.getStatus(callback)
     })

--- a/lib/device.js
+++ b/lib/device.js
@@ -145,7 +145,10 @@ class Device extends EventEmitter {
 
     this._connect(() => {
       this._launch(null, (err, player) => {
-        if (err) return callback(err)
+        if (err) {
+          this.client = null
+          return callback(err)
+        }
 
         this._onLaunch(player)
 
@@ -156,10 +159,7 @@ class Device extends EventEmitter {
 
   getStatus (callback) {
     this._tryJoin((err) => {
-      if (err) {
-        this.client = null
-        return callback(err)
-      }
+      if (err) return callback(err)
 
       this.player.getStatus(callback)
     })


### PR DESCRIPTION
Proposed fix for https://github.com/alxhotel/chromecast-api/issues/43