### PR TITLE
Allow music.youtube links

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-const YOUTUBE_REGEX = /http(?:s?):\/\/(?:www\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?‌​[\w\?‌​=]*)?/
+const YOUTUBE_REGEX = /http(?:s?):\/\/(?:www\.)?(?:music\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?‌​[\w\?‌​=]*)?/
 const URI_REGEX = /\w+:(\/?\/?)[^\s]+/
 const PATH_REGEX = /(\\\\?([^\\/]*[\\/])*)([^\\/]+)/
 


### PR DESCRIPTION
added the option to use music.youtube links (which have the same id as normal youtube)
by adding `(?:music\.)?` to the regex
full new regex:
```js
/http(?:s?):\/\/(?:www\.)?(?:music\.)?youtu(?:be\.com\/watch\?v=|\.be\/)([\w\-\_]*)(&(amp;)?‌​[\w\?‌​=]*)?/
```

#### Example:

this capture id `JYC8aINHFxc` from
https://music.youtube.com/watch?v=JYC8aINHFxc&list=PLtkJ7CALZYL9rGWDQ7V_PX60Kth5Nq3Ry
which is the same as
https://www.youtube.com/watch?v=JYC8aINHFxc