### PR TITLE
idempotent discovery

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  printWidth: 80,
+  trailingComma: 'es5',
+  tabWidth: 2,
+  semi: false,
+  singleQuote: true,
+  arrowParens: 'always',
+  endOfLine: 'auto',
+  spaceBeforeFunctionParen: true,
+  "space-before-function-paren": ["error", "always"],
+};

--- a/apps/default/DefaultMediaReceiver.js
+++ b/apps/default/DefaultMediaReceiver.js
@@ -1,9 +1,10 @@
 const mime = require('mime')
 
-const DefaultMediaReceiver = require('castv2-client').DefaultMediaReceiver
+const DefaultMediaReceiver =
+  require('../../lib/castv2-client').DefaultMediaReceiver
 
 class DefaultMediaReceiverApp extends DefaultMediaReceiver {
-  load (resource, opts, callback) {
+  load(resource, opts, callback) {
     if (!callback) callback = noop
 
     let media = {}
@@ -15,7 +16,7 @@ class DefaultMediaReceiverApp extends DefaultMediaReceiver {
 
       media = {
         contentId: resource,
-        contentType: mimeType || 'video/mp4'
+        contentType: mimeType || 'video/mp4',
       }
     } else {
       // By default
@@ -24,7 +25,7 @@ class DefaultMediaReceiverApp extends DefaultMediaReceiver {
 
       media = {
         contentId: resource.url,
-        contentType: mimeType || 'video/mp4'
+        contentType: mimeType || 'video/mp4',
       }
 
       if (resource.subtitles) {
@@ -39,7 +40,7 @@ class DefaultMediaReceiverApp extends DefaultMediaReceiver {
             trackContentType: 'text/vtt',
             name: subs.name,
             language: subs.language,
-            subtype: 'SUBTITLES'
+            subtype: 'SUBTITLES',
           })
           i++
         }
@@ -60,18 +61,26 @@ class DefaultMediaReceiverApp extends DefaultMediaReceiver {
           type: 0,
           metadataType: 0,
           title: resource.cover.title,
-          images: [{
-            url: resource.cover.url
-          }]
+          images: [
+            {
+              url: resource.cover.url,
+            },
+          ],
         }
       }
     }
 
     // If it's a video or audio file
-    if (media.contentType.indexOf('video') !== -1 || media.contentType.indexOf('audio') !== -1) {
+    if (
+      media.contentType.indexOf('video') !== -1 ||
+      media.contentType.indexOf('audio') !== -1
+    ) {
       options.autoplay = true
       options.currentTime = opts.startTime || 0
     }
+
+    // BUFFERED | LIVE
+    media.streamType = resource.streamType || 'BUFFERED'
 
     DefaultMediaReceiver.prototype.load.call(this, media, options, callback)
   }
@@ -79,4 +88,4 @@ class DefaultMediaReceiverApp extends DefaultMediaReceiver {
 
 module.exports = DefaultMediaReceiverApp
 
-function noop () {}
+function noop() {}

--- a/apps/youtube/Youtube.js
+++ b/apps/youtube/Youtube.js
@@ -1,10 +1,10 @@
-const Castv2Client = require('castv2-client')
+const Castv2Client = require('../../lib/castv2-client')
 const Application = Castv2Client.Application
 const MediaController = Castv2Client.MediaController
 const YoutubeController = require('./YoutubeController')
 
 class Youtube extends Application {
-  constructor (client, session) {
+  constructor(client, session) {
     super(client, session)
 
     this.media = this.createController(MediaController)
@@ -17,29 +17,31 @@ class Youtube extends Application {
     })
   }
 
-  static get APP_ID () { return '233637DE' }
+  static get APP_ID() {
+    return '233637DE'
+  }
 
-  getStatus (callback) {
+  getStatus(callback) {
     this.media.getStatus.apply(this.media, arguments)
   }
 
-  load (videoId) {
+  load(videoId) {
     this.youtube.load.apply(this.youtube, arguments)
   }
 
-  play (callback) {
+  play(callback) {
     this.media.play.apply(this.media, arguments)
   }
 
-  pause (callback) {
+  pause(callback) {
     this.media.pause.apply(this.media, arguments)
   }
 
-  stop (callback) {
+  stop(callback) {
     this.media.stop.apply(this.media, arguments)
   }
 
-  seek (currentTime, callback) {
+  seek(currentTime, callback) {
     this.media.seek.apply(this.media, arguments)
   }
 }

--- a/apps/youtube/YoutubeController.js
+++ b/apps/youtube/YoutubeController.js
@@ -1,11 +1,11 @@
-const Castv2Client = require('castv2-client')
+const Castv2Client = require('../../lib/castv2-client')
 const RequestResponseController = Castv2Client.RequestResponseController
 const YoutubeRemote = require('youtube-remote')
 
 const YOUTUBE_URN = 'urn:x-cast:com.google.youtube.mdx'
 
 class YoutubeController extends RequestResponseController {
-  constructor (client, sourceId, destinationId) {
+  constructor(client, sourceId, destinationId) {
     super(client, sourceId, destinationId, YOUTUBE_URN)
 
     const self = this
@@ -18,7 +18,7 @@ class YoutubeController extends RequestResponseController {
     })
   }
 
-  load (videoId, callback) {
+  load(videoId, callback) {
     if (!callback) callback = noop
 
     this.playVideo(videoId, function (err, res) {
@@ -27,7 +27,7 @@ class YoutubeController extends RequestResponseController {
     })
   }
 
-  playVideo (videoId, listId, callback) {
+  playVideo(videoId, listId, callback) {
     if (typeof listId === 'function') {
       callback = listId
       listId = ''
@@ -44,23 +44,23 @@ class YoutubeController extends RequestResponseController {
     })
   }
 
-  addToQueue (videoId) {
+  addToQueue(videoId) {
     this.remote.addToQueue(videoId)
   }
 
-  playNext (videoId) {
+  playNext(videoId) {
     this.remote.playNext(videoId)
   }
 
-  removeVideo (videoId) {
+  removeVideo(videoId) {
     this.remote.removeVideo(videoId)
   }
 
-  clearPlaylist () {
+  clearPlaylist() {
     this.remote.clearPlaylist()
   }
 
-  _getScreenId (callback) {
+  _getScreenId(callback) {
     if (!callback) callback = noop
 
     const self = this
@@ -79,12 +79,12 @@ class YoutubeController extends RequestResponseController {
     })
   }
 
-  _controlRequest (data, callback) {
+  _controlRequest(data, callback) {
     const self = this
 
     this.on('message', onMessage)
 
-    function onMessage (response) {
+    function onMessage(response) {
       self.removeListener('message', onMessage)
 
       if (response.type === 'INVALID_REQUEST') {
@@ -99,7 +99,7 @@ class YoutubeController extends RequestResponseController {
   }
 }
 
-function noop () {}
+function noop() {}
 
 // Hack for 'castv2-client'
 module.exports = (...args) => new YoutubeController(...args)

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,45 @@
+import prettier from "eslint-plugin-prettier";
+import globals from "globals";
+import babelParser from "@babel/eslint-parser";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+
+export default [...compat.extends("eslint:recommended", "prettier"), {
+    plugins: {
+        prettier,
+    },
+
+    languageOptions: {
+        globals: {
+            ...globals.node,
+        },
+
+        parser: babelParser,
+        ecmaVersion: 2018,
+        sourceType: "script",
+
+        parserOptions: {
+            requireConfigFile: false,
+
+            ecmaFeatures: {
+                jsx: true,
+            },
+        },
+    },
+
+    rules: {
+        "no-unreachable": 2,
+        "no-console": 1,
+        "prettier/prettier": 2,
+    },
+}];

--- a/lib/castv2-client.js
+++ b/lib/castv2-client.js
@@ -1,0 +1,6 @@
+// TODO: this is here to make testing multiple implementations of the `castv2-client`
+// const implementation =
+//   process.env.CASTV2_CLIENT_IMPLEMENTATION || 'castv2-client'
+// console.log(`castv2-client implementation: ${implementation}`)
+// module.exports = require(implementation)
+module.exports = require('castv2-client')

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,7 +6,6 @@ const parseString = require('xml2js').parseString
 const txt = require('dns-txt')()
 const debug = require('debug')('chromecast-api')
 const Device = require('./device')
-const { clearInterval } = require('timers')
 
 const UUID_REGEX =
   /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
@@ -69,6 +68,7 @@ class Client extends EventEmitter {
               try {
                 device.close()
               } catch (err) {
+                err
                 // do nothing
               }
 
@@ -101,6 +101,8 @@ class Client extends EventEmitter {
     })
 
     let emitEvent = false
+    let emitUpdatedEvent = false
+    let emitOnlineEvent = false
 
     if (oDevice) {
       debug('Update device: ', device)
@@ -112,6 +114,7 @@ class Client extends EventEmitter {
         device.manufacturer != oDevice.manufacturer ||
         device.modelName != oDevice.modelName
       ) {
+        emitUpdatedEvent = true
         emitEvent = true
       }
 
@@ -127,6 +130,7 @@ class Client extends EventEmitter {
       debug('New device: ', device)
 
       emitEvent = true
+      emitOnlineEvent = true
 
       // Add new device
       oDevice = new Device({
@@ -145,7 +149,14 @@ class Client extends EventEmitter {
 
     if (emitEvent) {
       this.emit('device', oDevice)
+    }
+
+    if (emitOnlineEvent) {
       this.emit('device_online', oDevice)
+    }
+
+    if (emitUpdatedEvent) {
+      this.emit('device_updated', oDevice)
     }
   }
 
@@ -411,6 +422,8 @@ class Client extends EventEmitter {
   destroy() {
     clearInterval(this.gcIntervalRef)
     clearInterval(this.updateIntervalRef)
+
+    this.removeAllListeners()
 
     if (this._mdns) {
       this._mdns.removeAllListeners()

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,10 +8,10 @@ const debug = require('debug')('chromecast-api')
 const Device = require('./device')
 
 /**
-* Chromecast client
-*/
+ * Chromecast client
+ */
 class Client extends EventEmitter {
-  constructor () {
+  constructor(options = {}) {
     super()
     debug('Initializing...')
 
@@ -21,14 +21,21 @@ class Client extends EventEmitter {
     // Public
     this.devices = []
 
+    // MDNS host strategy
+    this._mdns_host_stategy = options.mdns_host_stategy || 'srv'
+
     // Query MDNS
     this.queryMDNS()
+
+    // SSDP Device Endpoint HTTP Timeout
+    this._ssdp_device_endpoint_http_timeout =
+      options.ssdp_device_endpoint_http_timeout || 5000
 
     // Query SSDP
     this.querySSDP()
   }
 
-  _updateDevice (name) {
+  _updateDevice(name) {
     const device = this._devices[name]
 
     debug('New device: ', device)
@@ -37,7 +44,7 @@ class Client extends EventEmitter {
     const newDevice = new Device({
       name,
       friendlyName: device.name,
-      host: device.host
+      host: device.host,
     })
 
     // Add for public storage
@@ -46,13 +53,14 @@ class Client extends EventEmitter {
     this.emit('device', newDevice)
   }
 
-  queryMDNS () {
+  queryMDNS() {
     debug('Querying MDNS...')
 
     // MDNS
     this._mdns = mdns()
-    this._mdns.on('response', (response) => {
+    this._mdns.on('response', (response, rinfo) => {
       const onEachAnswer = (a) => {
+        const host = rinfo.address
         let name
 
         if (a.type === 'PTR' && a.name === '_googlecast._tcp.local') {
@@ -61,18 +69,32 @@ class Client extends EventEmitter {
           if (!this._devices[name]) {
             // New device
             this._devices[name] = { name: null, host: null }
+            if (this._mdns_host_stategy.toLowerCase() == 'rinfo') {
+              this._devices[name].host = host
+            }
           }
         }
 
         name = a.name
-        if (a.type === 'SRV' && this._devices[name] && !this._devices[name].host) {
+        if (
+          a.type === 'SRV' &&
+          this._devices[name] &&
+          (!this._devices[name].host || this._devices[name].host != host)
+        ) {
           debug('DNS [SRV]: ', a)
           // Update device
           this._devices[name].host = a.data.target
+          if (this._mdns_host_stategy.toLowerCase() == 'rinfo') {
+            this._devices[name].host = host
+          }
           if (this._devices[name].name) this._updateDevice(name)
         }
 
-        if (a.type === 'TXT' && this._devices[name] && !this._devices[name].name) {
+        if (
+          a.type === 'TXT' &&
+          this._devices[name] &&
+          !this._devices[name].name
+        ) {
           debug('DNS [TXT]: ', a)
 
           // Fix for array od data
@@ -105,11 +127,11 @@ class Client extends EventEmitter {
     this._triggerMDNS()
   }
 
-  _triggerMDNS () {
+  _triggerMDNS() {
     if (this._mdns) this._mdns.query('_googlecast._tcp.local', 'PTR')
   }
 
-  querySSDP () {
+  querySSDP() {
     debug('Querying SSDP...')
 
     // SSDP
@@ -117,54 +139,86 @@ class Client extends EventEmitter {
     this._ssdp.on('response', (headers, statusCode, rinfo) => {
       if (statusCode !== 200 || !headers.LOCATION) return
 
-      http.get(headers.LOCATION, (res) => {
-        let body = ''
-        res.on('data', (chunk) => {
-          body += chunk
-        })
-        res.on('end', () => {
-          parseString(body.toString(), { explicitArray: false, explicitRoot: false }, (err, result) => {
-            if (err) return
-            if (!result.device || !result.device.manufacturer || !result.device.friendlyName ||
-              result.device.manufacturer.indexOf('Google') === -1) return
-
-            // Friendly name
-            const matchUDN = body.match(/<UDN>(.+?)<\/UDN>/)
-            const matchFriendlyName = body.match(/<friendlyName>(.+?)<\/friendlyName>/)
-
-            if (!matchUDN || matchUDN.length !== 2) return
-            if (!matchFriendlyName || matchFriendlyName.length !== 2) return
-
-            // Generate chromecast style name
-            const udn = matchUDN[1]
-            const name = `Chromecast-${udn.replace(/uuid:/g, '').replace(/-/g, '')}._googlecast._tcp.local`
-            const friendlyName = matchFriendlyName[1]
-            const host = rinfo.address
-
-            if (!this._devices[name]) {
-              // New device
-              this._devices[name] = { name: friendlyName, host }
-              this._updateDevice(name)
-            } else if (!this._devices[name].name || !this._devices[name].host) {
-              // Update device
-              this._devices[name].name = friendlyName
-              this._devices[name].host = host
-              this._updateDevice(name)
-            }
+      http.get(
+        headers.LOCATION,
+        {
+          timeout: this._ssdp_device_endpoint_http_timeout,
+          signal: AbortSignal.timeout(this._ssdp_device_endpoint_http_timeout),
+        },
+        (res) => {
+          let body = ''
+          res.on('data', (chunk) => {
+            body += chunk
           })
-        })
-      })
+          res
+            .on('end', () => {
+              parseString(
+                body.toString(),
+                { explicitArray: false, explicitRoot: false },
+                (err, result) => {
+                  if (err) return
+                  if (
+                    !result.device ||
+                    result.device.deviceType !=
+                      'urn:dial-multiscreen-org:device:dial:1' ||
+                    !result.device.friendlyName
+                  )
+                    return
+
+                  // Friendly name
+                  const matchUDN = body.match(/<UDN>(.+?)<\/UDN>/)
+                  const matchFriendlyName = body.match(
+                    /<friendlyName>(.+?)<\/friendlyName>/
+                  )
+
+                  if (!matchUDN || matchUDN.length !== 2) return
+                  if (!matchFriendlyName || matchFriendlyName.length !== 2)
+                    return
+
+                  // Generate chromecast style name
+                  const udn = matchUDN[1]
+                  const name = `Chromecast-${udn.replace(/uuid:/g, '').replace(/-/g, '')}._googlecast._tcp.local`
+                  const friendlyName = matchFriendlyName[1]
+                  const host = rinfo.address
+
+                  if (!this._devices[name]) {
+                    // New device
+                    this._devices[name] = {
+                      name: friendlyName,
+                      host,
+                    }
+                    this._updateDevice(name)
+                  } else if (
+                    !this._devices[name].name ||
+                    !this._devices[name].host
+                  ) {
+                    // Update device
+                    this._devices[name].name = friendlyName
+                    this._devices[name].host = host
+                    this._updateDevice(name)
+                  }
+                }
+              )
+            })
+            .on('error', (err) => {
+              debug(
+                `failed executing SSDP http request: url=${headers.LOCATION}, err=${err}`
+              )
+              return
+            })
+        }
+      )
     })
 
     // Query SSDP
     this._triggerSSDP()
   }
 
-  _triggerSSDP () {
+  _triggerSSDP() {
     if (this._ssdp) this._ssdp.search('urn:dial-multiscreen-org:service:dial:1')
   }
 
-  update () {
+  update() {
     // Trigger again MDNS
     this._triggerMDNS()
 
@@ -172,7 +226,7 @@ class Client extends EventEmitter {
     this._triggerSSDP()
   }
 
-  destroy () {
+  destroy() {
     if (this._mdns) {
       this._mdns.removeAllListeners()
       this._mdns.destroy()

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,14 @@ const parseString = require('xml2js').parseString
 const txt = require('dns-txt')()
 const debug = require('debug')('chromecast-api')
 const Device = require('./device')
+const { clearInterval } = require('timers')
+
+const UUID_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i
+
+const UUID_REGEX_NO_HYPENS = /[0-9a-f]{32}/i
+
+const SSDP_DEVICE_TYPE = 'urn:dial-multiscreen-org:device:dial:1'
 
 /**
  * Chromecast client
@@ -22,35 +30,148 @@ class Client extends EventEmitter {
     this.devices = []
 
     // MDNS host strategy
-    this._mdns_host_stategy = options.mdns_host_stategy || 'srv'
+    this._mdns_host_stategy = options.mdns_host_stategy || 'rinfo'
 
     // Query MDNS
-    this.queryMDNS()
+    let mdns_enabled = true
+    if ('mdns_enabled' in options) {
+      mdns_enabled = options.mdns_enabled
+    }
+
+    if (mdns_enabled) {
+      this.queryMDNS()
+    }
 
     // SSDP Device Endpoint HTTP Timeout
     this._ssdp_device_endpoint_http_timeout =
       options.ssdp_device_endpoint_http_timeout || 5000
 
     // Query SSDP
-    this.querySSDP()
+    let ssdp_enabled = true
+    if ('ssdp_enabled' in options) {
+      ssdp_enabled = options.ssdp_enabled
+    }
+
+    if (ssdp_enabled) {
+      this.querySSDP()
+    }
+
+    if (options.gc_interval > 0 && options.gc_threshold > 0) {
+      this.gcIntervalRef = setInterval(() => {
+        debug('garbage collecting old devices')
+        this.devices.forEach((device, index) => {
+          const now = Math.floor(Date.now() / 1000)
+          const lastSeen = device.last_seen
+
+          if (lastSeen) {
+            if (now - lastSeen > options.gc_threshold) {
+              debug('garbage collecting device', device)
+              try {
+                device.close()
+              } catch (err) {
+                // do nothing
+              }
+
+              delete this._devices[device.name]
+              this.devices.splice(index, 1)
+              this.emit('device_offline', device)
+            }
+          }
+        })
+      }, 1000 * options.gc_interval)
+    }
+
+    if (options.update_interval > 0) {
+      this.updateIntervalRef = setInterval(() => {
+        this.update()
+      }, 1000 * options.update_interval)
+    }
   }
 
-  _updateDevice(name) {
-    const device = this._devices[name]
+  _updateDevice(uuid) {
+    const device = this._devices[uuid]
+    const lastSeen = Math.floor(Date.now() / 1000)
 
-    debug('New device: ', device)
+    //console.log('_updateDevice invoked', uuid)
 
-    // Add new device
-    const newDevice = new Device({
-      name,
-      friendlyName: device.name,
-      host: device.host,
+    // Get existing device if already on the stack
+    let oDevice
+    oDevice = this.devices.find((v) => {
+      return v.uuid == uuid
     })
 
-    // Add for public storage
-    this.devices.push(newDevice)
+    let emitEvent = false
 
-    this.emit('device', newDevice)
+    if (oDevice) {
+      debug('Update device: ', device)
+
+      if (
+        device.discoveryName != oDevice.name ||
+        device.friendlyName != oDevice.friendlyName ||
+        device.host != oDevice.host ||
+        device.manufacturer != oDevice.manufacturer ||
+        device.modelName != oDevice.modelName
+      ) {
+        emitEvent = true
+      }
+
+      //console.log('updating device', device, oDevice, emitEvent)
+
+      oDevice.name = device.discoveryName
+      oDevice.friendlyName = device.friendlyName
+      oDevice.host = device.host
+      oDevice.manufacturer = device.manufacturer
+      oDevice.modelName = device.modelName
+      oDevice.lastSeen = lastSeen
+    } else {
+      debug('New device: ', device)
+
+      emitEvent = true
+
+      // Add new device
+      oDevice = new Device({
+        uuid,
+        name: device.discoveryName,
+        friendlyName: device.friendlyName,
+        host: device.host,
+        manufacturer: device.manufacturer,
+        modelName: device.modelName,
+        lastSeen: lastSeen,
+      })
+
+      // Add for public storage
+      this.devices.push(oDevice)
+    }
+
+    if (emitEvent) {
+      this.emit('device', oDevice)
+      this.emit('device_online', oDevice)
+    }
+  }
+
+  parseUUID(data) {
+    let uuid
+    let matches
+
+    if (!uuid) {
+      matches = data.match(UUID_REGEX)
+      if (matches) {
+        uuid = matches[0].replace('-', '')
+      }
+    }
+
+    if (!uuid) {
+      matches = data.match(UUID_REGEX_NO_HYPENS)
+      if (matches) {
+        uuid = matches[0]
+      }
+    }
+
+    if (!uuid) {
+      uuid = data
+    }
+
+    return uuid
   }
 
   queryMDNS() {
@@ -61,61 +182,104 @@ class Client extends EventEmitter {
     this._mdns.on('response', (response, rinfo) => {
       const onEachAnswer = (a) => {
         const host = rinfo.address
-        let name
+        let uuid
+        let discoveryName
 
-        if (a.type === 'PTR' && a.name === '_googlecast._tcp.local') {
-          debug('DNS [PTR]: ', a)
-          name = a.data
-          if (!this._devices[name]) {
-            // New device
-            this._devices[name] = { name: null, host: null }
-            if (this._mdns_host_stategy.toLowerCase() == 'rinfo') {
-              this._devices[name].host = host
+        //console.log('mdns answer', a)
+
+        switch (a.type) {
+          case 'PTR':
+            if (a.name === '_googlecast._tcp.local') {
+              debug('DNS [PTR]: ', a)
+
+              uuid = this.parseUUID(a.data)
+              discoveryName = a.data
+              if (!this._devices[uuid]) {
+                // New device
+                this._devices[uuid] = {
+                  friendlyName: null,
+                  host: null,
+                  uuid,
+                  discoveryName,
+                }
+              } else {
+                if (discoveryName)
+                  this._devices[uuid].discoveryName = discoveryName
+
+                // do NOT announce until we have sufficient data
+                if (
+                  this._devices[uuid].host &&
+                  this._devices[uuid].friendlyName
+                )
+                  this._updateDevice(uuid)
+              }
             }
-          }
-        }
+            break
+          case 'SRV':
+            uuid = this.parseUUID(a.name)
+            discoveryName = a.name
 
-        name = a.name
-        if (
-          a.type === 'SRV' &&
-          this._devices[name] &&
-          (!this._devices[name].host || this._devices[name].host != host)
-        ) {
-          debug('DNS [SRV]: ', a)
-          // Update device
-          this._devices[name].host = a.data.target
-          if (this._mdns_host_stategy.toLowerCase() == 'rinfo') {
-            this._devices[name].host = host
-          }
-          if (this._devices[name].name) this._updateDevice(name)
-        }
+            if (this._devices[uuid]) {
+              debug('DNS [SRV]: ', a)
 
-        if (
-          a.type === 'TXT' &&
-          this._devices[name] &&
-          !this._devices[name].name
-        ) {
-          debug('DNS [TXT]: ', a)
+              // Update device
+              switch (this._mdns_host_stategy.toLowerCase()) {
+                case 'srv':
+                  this._devices[uuid].host = a.data.target
+                  break
+                case 'rinfo':
+                default:
+                  this._devices[uuid].host = host
+                  break
+              }
 
-          // Fix for array od data
-          let decodedData = {}
-          if (Array.isArray(a.data)) {
-            a.data.forEach((item) => {
-              const decodedItem = txt.decode(item)
-              Object.keys(decodedItem).forEach((key) => {
-                decodedData[key] = decodedItem[key]
-              })
-            })
-          } else {
-            decodedData = txt.decode(a.data)
-          }
+              if (discoveryName)
+                this._devices[uuid].discoveryName = discoveryName
 
-          const friendlyName = decodedData.fn || decodedData.n
-          if (friendlyName) {
-            // Update device
-            this._devices[name].name = friendlyName
-            if (this._devices[name].host) this._updateDevice(name)
-          }
+              // do NOT announce until we have sufficient data
+              if (this._devices[uuid].host && this._devices[uuid].friendlyName)
+                this._updateDevice(uuid)
+            }
+
+            break
+          case 'TXT':
+            uuid = this.parseUUID(a.name)
+            discoveryName = a.name
+
+            if (this._devices[uuid]) {
+              debug('DNS [TXT]: ', a)
+
+              // Fix for array od data
+              let decodedData = {}
+              if (Array.isArray(a.data)) {
+                a.data.forEach((item) => {
+                  const decodedItem = txt.decode(item)
+                  Object.keys(decodedItem).forEach((key) => {
+                    decodedData[key] = decodedItem[key]
+                  })
+                })
+              } else {
+                decodedData = txt.decode(a.data)
+              }
+
+              //console.log(decodedData)
+
+              const friendlyName = decodedData.fn || decodedData.n
+              const modelName = decodedData.d
+
+              // Update device
+              if (discoveryName)
+                this._devices[uuid].discoveryName = discoveryName
+              if (friendlyName) this._devices[uuid].friendlyName = friendlyName
+              if (modelName && !this._devices[uuid].modelName)
+                // prefer SSDP data over MDNS data
+                this._devices[uuid].modelName = modelName
+
+              // do NOT announce until we have sufficient data
+              if (this._devices[uuid].host && this._devices[uuid].friendlyName)
+                this._updateDevice(uuid)
+            }
+            break
         }
       }
 
@@ -139,6 +303,8 @@ class Client extends EventEmitter {
     this._ssdp.on('response', (headers, statusCode, rinfo) => {
       if (statusCode !== 200 || !headers.LOCATION) return
 
+      const host = rinfo.address
+
       http.get(
         headers.LOCATION,
         {
@@ -152,6 +318,7 @@ class Client extends EventEmitter {
           })
           res
             .on('end', () => {
+              //console.log('ssdp response body', body.toString())
               parseString(
                 body.toString(),
                 { explicitArray: false, explicitRoot: false },
@@ -159,43 +326,58 @@ class Client extends EventEmitter {
                   if (err) return
                   if (
                     !result.device ||
-                    result.device.deviceType !=
-                      'urn:dial-multiscreen-org:device:dial:1' ||
+                    result.device.deviceType != SSDP_DEVICE_TYPE ||
                     !result.device.friendlyName
                   )
                     return
 
-                  // Friendly name
-                  const matchUDN = body.match(/<UDN>(.+?)<\/UDN>/)
-                  const matchFriendlyName = body.match(
-                    /<friendlyName>(.+?)<\/friendlyName>/
-                  )
+                  //console.log('ssdp result', result.device)
 
-                  if (!matchUDN || matchUDN.length !== 2) return
-                  if (!matchFriendlyName || matchFriendlyName.length !== 2)
-                    return
+                  // Manufacturer
+                  const manufacturer = result.device.manufacturer
+
+                  // Model Name
+                  const modelName = result.device.modelName
+
+                  // Friendly name
+                  const friendlyName = result.device.friendlyName
+
+                  // UDN
+                  const udn = result.device.UDN
 
                   // Generate chromecast style name
-                  const udn = matchUDN[1]
-                  const name = `Chromecast-${udn.replace(/uuid:/g, '').replace(/-/g, '')}._googlecast._tcp.local`
-                  const friendlyName = matchFriendlyName[1]
-                  const host = rinfo.address
+                  // Note that if we later receive MDNS data for this same device it will be preferred over this generated name
+                  const discoveryName = `Chromecast-${udn.replace(/uuid:/g, '').replace(/-/g, '')}._googlecast._tcp.local`
 
-                  if (!this._devices[name]) {
+                  if (!friendlyName) return
+                  if (!udn) return
+
+                  const uuid = this.parseUUID(
+                    udn.replace(/uuid:/g, '').replace(/-/g, '')
+                  )
+
+                  if (!this._devices[uuid]) {
                     // New device
-                    this._devices[name] = {
-                      name: friendlyName,
+                    this._devices[uuid] = {
+                      discoveryName,
+                      friendlyName,
                       host,
+                      manufacturer,
+                      modelName,
                     }
-                    this._updateDevice(name)
-                  } else if (
-                    !this._devices[name].name ||
-                    !this._devices[name].host
-                  ) {
+                    this._updateDevice(uuid)
+                  } else {
                     // Update device
-                    this._devices[name].name = friendlyName
-                    this._devices[name].host = host
-                    this._updateDevice(name)
+                    if (discoveryName && !this._devices[uuid].discoveryName)
+                      // prefer MDNS data
+                      this._devices[uuid].discoveryName = discoveryName
+                    if (friendlyName)
+                      this._devices[uuid].friendlyName = friendlyName
+                    if (host) this._devices[uuid].host = host
+                    if (manufacturer)
+                      this._devices[uuid].manufacturer = manufacturer
+                    if (modelName) this._devices[uuid].modelName = modelName
+                    this._updateDevice(uuid)
                   }
                 }
               )
@@ -215,7 +397,7 @@ class Client extends EventEmitter {
   }
 
   _triggerSSDP() {
-    if (this._ssdp) this._ssdp.search('urn:dial-multiscreen-org:service:dial:1')
+    if (this._ssdp) this._ssdp.search(SSDP_DEVICE_TYPE)
   }
 
   update() {
@@ -227,6 +409,9 @@ class Client extends EventEmitter {
   }
 
   destroy() {
+    clearInterval(this.gcIntervalRef)
+    clearInterval(this.updateIntervalRef)
+
     if (this._mdns) {
       this._mdns.removeAllListeners()
       this._mdns.destroy()

--- a/lib/device.js
+++ b/lib/device.js
@@ -1,4 +1,4 @@
-const Client = require('castv2-client').Client
+const Client = require('./castv2-client').Client
 const EventEmitter = require('events')
 const debug = require('debug')('Device')
 const utils = require('./utils')
@@ -9,7 +9,7 @@ const DefaultMediaReceiver = require('../apps/default/DefaultMediaReceiver')
 
 const SUPPORTED_APPS = {
   [Youtube.APP_ID]: Youtube,
-  [DefaultMediaReceiver.APP_ID]: DefaultMediaReceiver
+  [DefaultMediaReceiver.APP_ID]: DefaultMediaReceiver,
 }
 const SUPPORTED_APP_IDS = Object.keys(SUPPORTED_APPS)
 
@@ -21,7 +21,7 @@ const SUPPORTED_APP_IDS = Object.keys(SUPPORTED_APPS)
  * @param {String} opts.host          IP address
  */
 class Device extends EventEmitter {
-  constructor (opts) {
+  constructor(opts) {
     super()
     this.name = opts.name
     this.friendlyName = opts.friendlyName
@@ -30,7 +30,7 @@ class Device extends EventEmitter {
     this.client = null
   }
 
-  _connect (callback) {
+  _connect(callback) {
     // Use a fresh client
     // TODO: reconsider reusing the client
     if (this.client) this.client.close()
@@ -53,7 +53,7 @@ class Device extends EventEmitter {
     })
   }
 
-  _launch (app, callback) {
+  _launch(app, callback) {
     if (!this.client) return
 
     debug('Launching app...')
@@ -62,7 +62,7 @@ class Device extends EventEmitter {
       if (err) return callback(err)
 
       const filtered = sessions.filter((session) => {
-        return (app)
+        return app
           ? session.appId === app.APP_ID
           : SUPPORTED_APP_IDS.includes(session.appId)
       })
@@ -79,7 +79,7 @@ class Device extends EventEmitter {
     })
   }
 
-  _playYoutube (link, callback) {
+  _playYoutube(link, callback) {
     this._launch(Youtube, (err, player) => {
       if (err) return callback(err)
 
@@ -91,7 +91,7 @@ class Device extends EventEmitter {
     })
   }
 
-  _playMedia (media, opts, callback) {
+  _playMedia(media, opts, callback) {
     this._launch(DefaultMediaReceiver, (err, player) => {
       if (err) return callback(err)
 
@@ -103,7 +103,7 @@ class Device extends EventEmitter {
     })
   }
 
-  _onLaunch (player) {
+  _onLaunch(player) {
     this.player = player
 
     this.player.on('status', (status) => {
@@ -117,7 +117,7 @@ class Device extends EventEmitter {
     })
   }
 
-  play (resource, opts, callback) {
+  play(resource, opts, callback) {
     // Handle optional parameters
     if (typeof opts === 'function') {
       callback = opts
@@ -140,7 +140,7 @@ class Device extends EventEmitter {
     })
   }
 
-  _tryJoin (callback) {
+  _tryJoin(callback) {
     // We are already connected
     if (this.client) return callback()
 
@@ -159,14 +159,14 @@ class Device extends EventEmitter {
     })
   }
 
-  _tryConnect (callback) {
+  _tryConnect(callback) {
     // We are already connected
     if (this.client) return callback()
 
     this._connect(callback)
   }
 
-  getStatus (callback) {
+  getStatus(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -176,7 +176,7 @@ class Device extends EventEmitter {
     })
   }
 
-  getReceiverStatus (callback) {
+  getReceiverStatus(callback) {
     if (!callback) callback = noop
 
     this._tryConnect((err) => {
@@ -185,7 +185,7 @@ class Device extends EventEmitter {
     })
   }
 
-  seekTo (newCurrentTime, callback) {
+  seekTo(newCurrentTime, callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -195,7 +195,7 @@ class Device extends EventEmitter {
     })
   }
 
-  seek (seconds, callback) {
+  seek(seconds, callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -209,7 +209,7 @@ class Device extends EventEmitter {
     })
   }
 
-  pause (callback) {
+  pause(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -219,7 +219,7 @@ class Device extends EventEmitter {
     })
   }
 
-  unpause (callback) {
+  unpause(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -229,7 +229,7 @@ class Device extends EventEmitter {
     })
   }
 
-  resume (callback) {
+  resume(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -239,7 +239,7 @@ class Device extends EventEmitter {
     })
   }
 
-  getVolume (callback) {
+  getVolume(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -249,7 +249,7 @@ class Device extends EventEmitter {
     })
   }
 
-  setVolume (volume, callback) {
+  setVolume(volume, callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -259,7 +259,7 @@ class Device extends EventEmitter {
     })
   }
 
-  stop (callback) {
+  stop(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -269,7 +269,7 @@ class Device extends EventEmitter {
     })
   }
 
-  setVolumeMuted (muted, callback) {
+  setVolumeMuted(muted, callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -279,49 +279,59 @@ class Device extends EventEmitter {
     })
   }
 
-  subtitlesOff (callback) {
+  subtitlesOff(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
       if (err) return callback(err)
 
-      this.player.media.sessionRequest({
-        type: 'EDIT_TRACKS_INFO',
-        activeTrackIds: []
-      }, callback)
+      this.player.media.sessionRequest(
+        {
+          type: 'EDIT_TRACKS_INFO',
+          activeTrackIds: [],
+        },
+        callback
+      )
     })
   }
 
-  changeSubtitles (subId, callback) {
+  changeSubtitles(subId, callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
       if (err) return callback(err)
 
-      this.player.media.sessionRequest({
-        type: 'EDIT_TRACKS_INFO',
-        activeTrackIds: [subId]
-      }, callback)
+      this.player.media.sessionRequest(
+        {
+          type: 'EDIT_TRACKS_INFO',
+          activeTrackIds: [subId],
+        },
+        callback
+      )
     })
   }
 
-  changeSubtitlesSize (fontScale, callback) {
+  changeSubtitlesSize(fontScale, callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
       if (err) return callback(err)
 
-      if (!this.player.subtitlesStyle) return callback(new Error('Subtitle styles not defined'))
+      if (!this.player.subtitlesStyle)
+        return callback(new Error('Subtitle styles not defined'))
 
       this.player.subtitlesStyle.fontScale = fontScale
-      this.player.media.sessionRequest({
-        type: 'EDIT_TRACKS_INFO',
-        textTrackStyle: this.player.subtitlesStyle
-      }, callback)
+      this.player.media.sessionRequest(
+        {
+          type: 'EDIT_TRACKS_INFO',
+          textTrackStyle: this.player.subtitlesStyle,
+        },
+        callback
+      )
     })
   }
 
-  getCurrentTime (callback) {
+  getCurrentTime(callback) {
     if (!callback) callback = noop
 
     this._tryJoin((err) => {
@@ -335,7 +345,7 @@ class Device extends EventEmitter {
     })
   }
 
-  close (callback) {
+  close(callback) {
     if (!callback) callback = noop
 
     if (!this.client) return
@@ -350,6 +360,6 @@ class Device extends EventEmitter {
   }
 }
 
-function noop () {}
+function noop() {}
 
 module.exports = Device

--- a/lib/device.js
+++ b/lib/device.js
@@ -23,9 +23,13 @@ const SUPPORTED_APP_IDS = Object.keys(SUPPORTED_APPS)
 class Device extends EventEmitter {
   constructor(opts) {
     super()
+    this.uuid = opts.uuid
     this.name = opts.name
     this.friendlyName = opts.friendlyName
     this.host = opts.host
+    this.manufacturer = opts.manufacturer
+    this.modelName = opts.modelName
+    this.lastSeen = opts.lastSeen
 
     this.client = null
   }

--- a/package.json
+++ b/package.json
@@ -4,19 +4,27 @@
   "description": "Chromecast streaming module all in JS",
   "main": "index.js",
   "scripts": {
+    "eslint": "eslint .",
+    "prettier": "prettier --config .prettierrc.js '**/*.js' --write",
     "test": "standard"
   },
   "dependencies": {
-    "castv2-client": "1.2.0",
+    "castv2-client": "^1.2.0",
     "debug": "^4.1.1",
     "dns-txt": "^2.0.2",
     "mime": "^3.0.0",
     "multicast-dns": "^7.2.0",
     "node-ssdp": "^4.0.0",
-    "xml2js": "^0.4.23",
+    "xml2js": "^0.6.2",
     "youtube-remote": "^1.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.26.0",
+    "@babel/eslint-parser": "^7.25.9",
+    "eslint": "^9.14.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.1",
+    "prettier": "^3.3.3",
     "standard": "latest"
   },
   "engines": {


### PR DESCRIPTION
This PR introduces logic to ensure (as well as possible) idempotency of `devices`. It does this by utilizing a new `uuid` attribute on each device and ensuring that as new `mdns` or `ssdp` data arrives that the corresponding `device` simply has it's attributes updated if/when appropriate vs creating a new entry.

Various other features are peppered throughout:

- 3 additional properties on each device: `manufacturer`, `modelName`, and `lastSeen`
- devices can now be garbage collected (based on `lastSeen` attribute)
- non-google devices are now properly discovered (ie: android tvs, etc)
- new events for `device_online` and `device_offline` (garbage collected) and `device_updated`
  - existing `device` event behaves in a backwards-compatible way
  - more robust change detection logic has been put in place to prevent sending useless (actual noops) events
- `http.get` usage now has proper error handling
- `http.get` now has a configurable `timeout` setting to prevent hangs
- `streamType` can be set when sending media
- `rinfo` is used by default to detect `mdns` discovered `host` (vs parsing the `foo.local` address from DNS data)
- added dev dependencies to support modern js formatting and linting